### PR TITLE
Fixes for ruby 3.4

### DIFF
--- a/yam.gemspec
+++ b/yam.gemspec
@@ -24,7 +24,7 @@ require 'date'
 
 Gem::Specification.new do |s|
   s.name             = 'yam'
-  s.version          = Yammer::Version
+  s.version          = Yammer::Version.to_s
 
   s.date             = Date.today.to_s
   s.summary          = "Yammer API Client"
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.authors          = ["Kevin Mutyaba"]
   s.email            = %q{kmutyaba@yammer-inc.com}
   s.homepage         = 'http://yammer.github.io/yam'
-  s.rubygems_version = Yammer::Version
+  s.rubygems_version = Yammer::Version.to_s
   s.files            = `git ls-files`.split("\n")
   s.require_paths    = ['lib']
 


### PR DESCRIPTION
`Yammer::Version` is passed as a class and the latest rubygems throws the below exception. 

> Gem::Exception: ruby_code case not handled: Class
>   /Users/bsunder/.rvm/rubies/ruby-3.4.2/lib/ruby/site_ruby/3.4.0/rubygems/specification.rb:2307:in 'Gem::Specification#ruby_code'
>           /Users/bsunder/.rvm/rubies/ruby-3.4.2/lib/ruby/site_ruby/3.4.0/rubygems/specification.rb:2462:in 'block in Gem::Specification#to_ruby'
>           /Users/bsunder/.rvm/rubies/ruby-3.4.2/lib/ruby/site_ruby/3.4.0/rubygems/specification.rb:2458:in 'Array#each'
>           /Users/bsunder/.rvm/rubies/ruby-3.4.2/lib/ruby/site_ruby/3.4.0/rubygems/specification.rb:2458:in 'Gem::Specification#to_ruby'
>           /Users/bsunder/.rvm/rubies/ruby-3.4.2/lib/ruby/site_ruby/3.4.0/bundler/source/git.rb:331:in 'block (2 levels) in Bundler::Source::Git#serialize_gemspecs_in'
>           /Users/bsunder/.rvm/rubies/ruby-3.4.2/lib/ruby/site_ruby/3.4.0/bundler/source/git.rb:331:in 'IO.open'
>           /Users/bsunder/.rvm/rubies/ruby-3.4.2/lib/ruby/site_ruby/3.4.0/bundler/source/git.rb:331:in 'block in Bundler::Source::Git#serialize_gemspecs_in'
>           /Users/bsunder/.rvm/rubies/ruby-3.4.2/lib/ruby/site_ruby/3.4.0/bundler/source/git.rb:323:in 'Array#each'
>           /Users/bsunder/.rvm/rubies/ruby-3.4.2/lib/ruby/site_ruby/3.4.0/bundler/source/git.rb:323:in 'Bundler::Source::Git#serialize_gemspecs_in'